### PR TITLE
Fixes for gem errors I noticed, asset/.env support

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,4 +1,5 @@
 load 'deploy'
 # Uncomment if you are using Rails' asset pipeline
+#load 'deploy/assets'
 load 'config/deploy'
 require "bundler/capistrano"

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'therubyracer', platforms: :ruby
 gem 'delayed_job_active_record'
 gem 'nokogiri'
 
-group :development do
+#gem 'dotenv-rails' # Enviroment vars manager
+
+group :deploy do
   gem "capistrano-kyan"
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,6 +22,15 @@ namespace :deploy do
   task :restart, :roles => :app, :except => { :no_release => true } do
     run "#{try_sudo} touch #{File.join(current_path,'tmp','restart.txt')}"
   end
+
+  # Uncomment if using enviroment vars
+  # Overrides add_env method defined by capistrano-kyan gem
+  #task :add_env do
+    #env_release_path = "#{release_path}/.env"
+    #env_shared_path = "#{shared_path}/.env"
+
+    #run "ln -s #{env_shared_path} #{env_release_path}"
+  #end
 end
 
 after "deploy:setup",           "kyan:vhost:setup"


### PR DESCRIPTION
Moves capistrano-kyan gem into deploy group - It was complaing it needed
capistrano v2 when I was starting my development enviroment.

Added in commented out assets pipeline deployment require.

added the dotenv-rails gem - it loads up .env variables, useful when
moving from heroku to VPS.
